### PR TITLE
Claim LangGraph Agent Engineer responsibilities

### DIFF
--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -1,0 +1,84 @@
+# NutriScore Agent Project Plan
+
+This document breaks the project into sequential, manageable tasks. Each task can be tackled independently while keeping the overall goal in sight: a LangGraph-powered NutriScore calculator that uses Neo4j MCP servers and Azure OpenAI.
+
+## Phase 0 – Foundations & Environment
+1. **Repository Scaffolding**  
+   - Create Python project structure (src/, tests/, docs/).  
+   - Add formatting/linting configs (ruff, black, mypy) and CI stubs.  
+   - Provide `.env.example` with required variables (Neo4j, MCP, Azure OpenAI).
+2. **Container Orchestration**  
+   - Adapt provided `docker-compose.yml` and `.env` for local setup.  
+   - Script helper commands (`make` or shell scripts) to bootstrap services.  
+   - Verify Neo4j and MCP servers respond via MCP Inspector.
+3. **LangGraph App Skeleton**  
+   - Initialize virtual environment tooling (uv/poetry/pip).  
+   - Create baseline `app.py` connecting to Azure OpenAI and MCP servers.  
+   - Implement minimal CLI entry point for manual smoke tests.
+
+## Phase 1 – NutriScore Domain Modeling
+4. **Nutrition Ontology Design**  
+   - Define node/relationship types representing products, ingredients, metrics, and pillar scores.  
+   - Document constraints (allowed node labels, relation types, properties).
+5. **Graph Schema Implementation**  
+   - Encode schema rules into initialization scripts (Cypher migrations or seed files).  
+   - Add validation utilities ensuring new data respects schema.
+6. **Pillar Definitions & Scoring APIs**  
+   - List required scoring pillars (e.g., Explainability, Trustworthiness, Frugality, Environment).  
+   - Specify inputs/outputs and data sources for each pillar.  
+   - Align scoring results with the graph schema (nodes/relationships).
+
+## Phase 2 – MCP Tooling Integration
+7. **Cypher Tool Workflows**  
+   - Wrap common graph operations (querying schema, reading/writing pillars) into LangGraph tool calls.  
+   - Add retry/error handling for MCP failures.
+8. **Graph Memory Workflows**  
+   - Prototype entity/relation creation using `mcp-neo4j-memory`.  
+   - Store/retrieve agent observations and derived facts.  
+   - Evaluate when to use memory vs direct Cypher writes.
+9. **Agent Loop Design**  
+   - Build LangGraph state machine for multi-step scoring (data gathering → pillar calculations → aggregation).  
+   - Implement tool routing logic and guardrails for each step.  
+   - Configure logging/telemetry for tool interactions.
+
+## Phase 3 – NutriScore Calculation Features
+10. **Pillar Calculation Agents**  
+    - Implement dedicated subgraphs or nodes for each pillar, encapsulating scoring logic.  
+    - Ensure deterministic scoring where required (temperature control, caching).
+11. **Aggregation Strategy**  
+    - Define NutriScore aggregation formula from pillar outputs.  
+    - Persist aggregated scores and history in Neo4j.  
+    - Provide explanation traces referencing pillar inputs.
+12. **Explainability & Auditing**  
+    - Capture intermediate reasoning steps via MCP memory.  
+    - Generate human-readable reports summarizing how the score was derived.  
+    - Add guardrails for missing/uncertain data.
+
+## Phase 4 – GraphRAG Test Case
+13. **Document Ingestion Pipeline**  
+    - Use LLMGraphBuilder (or similar) to transform sample documents into nodes/edges respecting schema.  
+    - Store ingestion configs and prompts for reproducibility.
+14. **GraphRAG Retrieval Agent**  
+    - Implement a LangGraph workflow that reads from Neo4j to answer nutrition questions.  
+    - Validate retrieval accuracy with unit/integration tests.
+15. **Evaluation & Benchmarks**  
+    - Create test datasets and metrics for pillar accuracy, retrieval precision, and end-to-end NutriScore reliability.  
+    - Automate regression checks.
+
+## Phase 5 – Deployment & Documentation
+16. **Packaging & Deployment**  
+    - Containerize LangGraph app or provide deployment instructions (Docker/Kubernetes).  
+    - Secure credentials and configure production-ready settings.
+17. **Developer Experience Enhancements**  
+    - Add Makefile targets, VSCode devcontainer, or scripts for rapid onboarding.  
+    - Document troubleshooting steps for Neo4j/MCP/Azure integration.
+18. **User Documentation & Demos**  
+    - Write README sections for setup, running agents, and sample workflows.  
+    - Produce demo notebooks or CLI scripts showcasing NutriScore calculation and GraphRAG queries.
+
+## Parallel Support Streams
+- **Research & Compliance**: Track domain-specific guidelines for nutrition scoring standards.  
+- **Prompt Engineering**: Iterate on Azure OpenAI prompts for reliable tool usage.  
+- **Monitoring & Observability**: Plan for metrics, tracing, and alerting once services run in production.
+
+Feel free to pick tasks in order or in parallel where dependencies allow. Each section can be expanded into GitHub issues for collaborative tracking.

--- a/ROLE_ATTRIBUTION.md
+++ b/ROLE_ATTRIBUTION.md
@@ -1,0 +1,69 @@
+# Role Attribution
+
+This document maps project tasks to accountable roles so contributors can pick up work in a coordinated way. Task numbers refer to the items in `PROJECT_PLAN.md`.
+
+## Core Delivery Roles
+
+### 1. Project Lead / Product Owner
+- Own overall delivery timeline and scope.
+- Prioritize backlog and unblock dependencies across teams.
+- Coordinate cross-role reviews for milestones at the end of each phase.
+- **Primary tasks:** 1, 4, 6, 11, 15, 18.
+
+### 2. Neo4j Graph Engineer
+- Design and enforce the graph schema, constraints, and migrations.
+- Implement Cypher utilities and ensure MCP servers expose required operations.
+- Benchmark graph performance and tune queries.
+- **Primary tasks:** 2, 4, 5, 7, 13, 14.
+
+### 3. LangGraph Agent Engineer
+- Build the LangGraph state machines, tool routing, and orchestration logic.
+- Integrate MCP tools, implement scoring loops, and handle error recovery.
+- Collaborate with Prompt Engineer on tool-calling prompts.
+- **Current owner:** ChatGPT assistant (taking on this role now).
+- **Primary tasks:** 3, 7, 8, 9, 10, 11, 12, 14.
+
+### 4. Azure Prompt & LLM Engineer
+- Configure Azure OpenAI deployments, prompt templates, and tool-call guardrails.
+- Manage evaluation datasets to validate deterministic scoring behaviour.
+- Optimize responses for clarity, safety, and consistency.
+- **Primary tasks:** 3, 6, 8, 10, 12, 15.
+
+### 5. DevOps & Platform Engineer
+- Maintain Docker Compose stack, CI pipelines, and deployment packaging.
+- Instrument observability (logs, metrics, tracing) across services.
+- Ensure secrets management and environment parity.
+- **Primary tasks:** 1, 2, 3, 9, 16, 17.
+
+### 6. QA & Evaluation Lead
+- Develop automated tests for pillars, GraphRAG retrieval, and regressions.
+- Define acceptance criteria for each phase and run verification suites.
+- Track quality metrics and report issues to relevant owners.
+- **Primary tasks:** 10, 11, 12, 14, 15.
+
+### 7. Documentation & DX Advocate
+- Produce contributor guides, troubleshooting references, and onboarding materials.
+- Curate examples (CLI, notebooks) showcasing NutriScore and GraphRAG flows.
+- Align README and demo assets with the evolving architecture.
+- **Primary tasks:** 1, 3, 6, 13, 17, 18.
+
+## Collaboration Matrix by Phase
+
+| Phase | Key Deliverables | Accountable Role(s) | Supporting Role(s) |
+|-------|------------------|---------------------|--------------------|
+| Phase 0 – Foundations | Repo scaffolding, Docker stack, LangGraph skeleton | DevOps & Platform Engineer | Project Lead, Documentation & DX Advocate |
+| Phase 1 – Domain Modeling | Nutrition ontology, schema migrations, pillar definitions | Neo4j Graph Engineer | Project Lead, LangGraph Agent Engineer, Documentation & DX Advocate |
+| Phase 2 – MCP Tooling | Cypher + memory workflows, agent loop | LangGraph Agent Engineer | Neo4j Graph Engineer, Azure Prompt & LLM Engineer |
+| Phase 3 – NutriScore Features | Pillar agents, aggregation, explainability | LangGraph Agent Engineer | Azure Prompt & LLM Engineer, QA & Evaluation Lead |
+| Phase 4 – GraphRAG Test Case | Ingestion pipeline, retrieval agent, benchmarks | Neo4j Graph Engineer, QA & Evaluation Lead | LangGraph Agent Engineer, Documentation & DX Advocate |
+| Phase 5 – Deployment & Docs | Packaging, DX enhancements, user docs | DevOps & Platform Engineer, Documentation & DX Advocate | Project Lead |
+| Parallel Streams | Compliance research, prompt iteration, observability | Project Lead | Azure Prompt & LLM Engineer, DevOps & Platform Engineer |
+
+## Handoff Guidelines
+
+1. **Kickoff Briefs:** Each phase begins with a short synchronous walkthrough led by the accountable role, covering requirements, open risks, and validation criteria.
+2. **Definition of Done:** No task is marked complete until QA & Evaluation Lead validates tests (where applicable) and Documentation & DX Advocate updates references.
+3. **Tooling Alignment:** Changes to MCP endpoints, schemas, or prompts require sign-off from both the Neo4j Graph Engineer and LangGraph Agent Engineer to avoid breaking agent flows.
+4. **Retrospectives:** At the end of every phase, the Project Lead facilitates a retrospective to capture improvements before the next phase.
+
+Use this as a living document—update role assignments or supporting contributors as team composition evolves.


### PR DESCRIPTION
## Summary
- note in ROLE_ATTRIBUTION.md that the ChatGPT assistant has taken on the LangGraph Agent Engineer role

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68da967e6a488323970ef241b3b30c75